### PR TITLE
`@currentState` should be set before calling `state.enter` and triggering the `enter:state` event

### DIFF
--- a/src/backbone.statemanager.coffee
+++ b/src/backbone.statemanager.coffee
@@ -48,13 +48,14 @@ Backbone.StateManager = ((Backbone, _) ->
       # Find the the state we will be transitioning to and if it has a onBeforeEnterFrom method, call it
       state.findTransition('onBeforeEnterFrom', options.fromState)? options
 
+      @currentState = name
+
       state.enter options
 
       state.findTransition('onEnterFrom', options.fromState)? options
 
       @trigger 'enter:state', name, state, options
 
-      @currentState = name
       @
 
     exitState : (options = {}) ->

--- a/src/spec/backbone.statemanager.spec.coffee
+++ b/src/spec/backbone.statemanager.spec.coffee
@@ -182,6 +182,34 @@ describe 'Backbone.StateManager', =>
 
         it 'sets the currentState', => expect(@stateManager.currentState).toEqual 'noTransitions'
 
+      describe 'order of calls', =>
+        currentState_in_stateenter_call = null
+        currentState_in_enterstate_event = null
+        state_name_in_enterstate_event = null
+
+        beforeEach =>
+          sm = @stateManager
+          spyOn(@_states.noTransitions, 'enter').andCallFake(->
+            currentState_in_stateenter_call = sm.getCurrentState()
+          )
+          @stateManager.on 'enter:state', (name) ->
+            currentState_in_enterstate_event = sm.getCurrentState()
+            state_name_in_enterstate_event = name
+          @stateManager.states.find.andReturn new Backbone.StateManager.State 'noTransitions', @_states.noTransitions
+          @
+
+        it 'sets the currentState before calling state.enter', =>
+          @stateManager.currentState = 'some_state'
+          @stateManager.enterState 'noTransitions'
+          expect(currentState_in_stateenter_call).toEqual('noTransitions')
+
+        it 'sets the currentState before triggering enter:state', =>
+          @stateManager.currentState = 'some_state'
+          @stateManager.enterState 'noTransitions'
+          expect(currentState_in_enterstate_event).toEqual('noTransitions')
+          expect(state_name_in_enterstate_event).toEqual('noTransitions')
+
+
       describe 'on states with transitions set', =>
         beforeEach =>
           @stateManager.states.find.andReturn enter : (->), __proto__ : Backbone.StateManager.State.prototype


### PR DESCRIPTION
Fixes #7 : As @kenzic noted, a callback listening to `enter:state` and reading the StateManager's `@currentState` property would get an incorrect value.

I think such callbacks, as well as the `state.enter` method, should be called after setting `@currentState` to the name of the new state being entered, so that if they read `@currentState`, they get the correct value.
